### PR TITLE
Move setlocal to correct location

### DIFF
--- a/package_builder/common_build_python.bat
+++ b/package_builder/common_build_python.bat
@@ -71,6 +71,8 @@ set PYTHONVERND=%PYTHONVER:.=%
 %ZIPEXE% x "%~dp0\python_deps\python_clean_%PYTHONVER%.%PYTHONPATCH%.zip" -y -o%PYTHONDIR%
 if %errorlevel% neq 0 exit /b %errorlevel%
 
+setlocal
+
 cd %PYTHONDIR%
 
 del /f /q %~dp0\pip_upgrade.log
@@ -78,8 +80,6 @@ del /f /q %~dp0\pip_requirements.log
 
 %PYTHON% -m ensurepip
 if %errorlevel% neq 0 exit /b %errorlevel%
-
-setlocal
 
 set "PATH=%PYTHONDIR%\Scripts;%PATH%"
 


### PR DESCRIPTION
in https://github.com/ISISComputingGroup/uktena/commit/a0427a1dda68ca9215341b11700270c43f291bab `setlocal` was added a bit too late as in after `cd %PYTHONDIR%` - this means there is a unintended directory change when scope ends. To restore previous directory behaviour need to move setlcoal earlier